### PR TITLE
When ATCEngine is initialized with root_url, the constructor

### DIFF
--- a/pharmpy/atc.py
+++ b/pharmpy/atc.py
@@ -18,7 +18,7 @@ class ATCEngine:
         self.root_url = root_url
         self.cache_fn = cache_fn
         self.cache = utils.read_cache(self.cache_fn) # rxcui => atc
-        self.rce = RxCUIEngine(cache_only=cache_only)
+        self.rce = RxCUIEngine(root_url=root_url, cache_only=cache_only)
         self.session = rq.Session()
         self.cache_only = cache_only
 


### PR DESCRIPTION
 does not pass root_url to the RxCUIEngine. Therefore,
the incorrect url is queried instead and an error is raised.

from pharmpy.atc import ATCEngine
import unittest

class ATCEngineTestCase(unittest.TestCase):

    def test_atc(self):
        ae = ATCEngine(root_url="http://host.docker.internal:4000/REST")
        print(vars(ae))
        out = ae.get_atc("50090347201")
        self.assertEqual(out[0]["id"], "A10BH")
        out = ae.get_atc(["50090347201"])
        self.assertEqual(out[0][0]["id"], "A10BH")

if __name__=="__main__":
    unittest.main()

{'root_url': 'http://host.docker.internal:4000/REST', 'cache_fn': 'data/cache_atc.json', 'cache': {}, 'rce': <pharmpy.rxcui.RxCUIEngine object at 0x7f72b34ff358>, 'session': <requests.sessions.Session object at 0x7f72b34ff748>, 'cache_only': False}
E
======================================================================
ERROR: test_atc (__main__.ATCEngineTestCase)
----------------------------------------------------------------------

Traceback (most recent call last):
  File "mederrata_stage1/scripts/dataformatting/shortscripts/atc_crosswalk_test.py", line 9, in test_atc
    out = ae.get_atc("50090347201")
  File "/usr/local/lib/python3.6/dist-packages/pharmpy/atc.py", line 77, in get_atc
    rxcui_lst = self.rce.get_rxcui(ndc_lst)
  File "/usr/local/lib/python3.6/dist-packages/pharmpy/rxcui.py", line 46, in get_rxcui
    r = self.session.get(url)
  File "/usr/local/lib/python3.6/dist-packages/requests/sessions.py", line 543, in get
    return self.request('GET', url, **kwargs)
  File "/usr/local/lib/python3.6/dist-packages/requests/sessions.py", line 530, in request
    resp = self.send(prep, **send_kwargs)
  File "/usr/local/lib/python3.6/dist-packages/requests/sessions.py", line 643, in send
    r = adapter.send(request, **kwargs)
  File "/usr/local/lib/python3.6/dist-packages/requests/adapters.py", line 516, in send
    raise ConnectionError(e, request=request)
requests.exceptions.ConnectionError: HTTPConnectionPool(host='localhost', port=4000): Max retries exceeded with url: /REST/ndcstatus.json?ndc=50090347201 (Caused by NewConnectionError('<urllib3.connection.HTTPConnection object at 0x7f72b34ff080>: Failed to establish a new connection: [Errno 111] Connection refused',))

Closes #1